### PR TITLE
Allow nullable lane and skill recommendations in messages

### DIFF
--- a/src/main/kotlin/model/Message.kt
+++ b/src/main/kotlin/model/Message.kt
@@ -19,7 +19,7 @@ class Message(
     /**
      * @return the order to control the specified lane.
      */
-    val lane: LaneType,
+    val lane: LaneType?,
     /**
      * @return the order to learn the specified skill.
      * *
@@ -31,7 +31,7 @@ class Message(
      *
      * * The field value may not be available in all game modes.
      */
-    val skillToLearn: SkillType, rawMessage: ByteArray) {
+    val skillToLearn: SkillType?, rawMessage: ByteArray) {
   private val rawMessage: ByteArray
 
   init {


### PR DESCRIPTION
Hi!
There is a number of games (see http://russianaicup.ru/game/view/83827 f.e.) where Kotlin strategies just exit on the first tick. This seems to be because of lane and skills could be null in messages.
Please accept this patch (or fix it another way) and ask organizers to update the Kotlin pack. They said they'll try to do this ASAP.